### PR TITLE
[GH-2] Add CI workflow for verifying frontend and backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  frontend:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./web
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: 21.6.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Lint frontend
+        run: npm run lint
+
+      - name: Format frontend
+        run: npm run format-ci
+
+  backend:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./server
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup Python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install Django==5.0.2 'channels[daphne]' ruff black
+
+      - name: Lint backend
+        run: ruff check
+
+      - name: Format backend
+        run: black --check .
+
+      # - name: Test
+      #   run: python manage.py test

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier . --write",
+    "format-ci": "prettier . --check"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",


### PR DESCRIPTION
### Description

- Adds a GitHub workflow for automating building, linting, and formatting the frontend/backend whenever a change is made. The jobs are configured to run on pull requests to ensure that all checks pass before changes can be merged. 
- Adds a package script to format the frontend using `prettier`.

### Related Issues

Resolves #2 

### Additional Notes

- The `backend` job is largely stubbed until a Python project is bootstrapped.