### PR TITLE
[GH-46] Support multiplayer connections and add starter squares

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,6 @@
 Django==5.0.2
 channels[daphne]>=4.0
+channels_redis
 ruff
 black
 python-dotenv

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -77,6 +77,16 @@ TEMPLATES = [
 ASGI_APPLICATION = "server.asgi.application"
 WSGI_APPLICATION = "server.wsgi.application"
 
+# Channel Layers
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("127.0.0.1", 6379)],
+        },
+    },
+}
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases

--- a/server/ws/clueless.py
+++ b/server/ws/clueless.py
@@ -24,12 +24,12 @@ clue_cards = {
 }
 
 character_positions = {
-    "miss_scarlett": (0, 0),
-    "colonel_mustard": (0, 0),
-    "mrs_white": (0, 0),
-    "mr_green": (0, 0),
-    "mrs_peacock": (0, 0),
-    "professor_plum": (0, 0),
+    "miss_scarlett": (3, 0),
+    "colonel_mustard": (4, 1),
+    "mrs_white": (3, 4),
+    "mr_green": (1, 4),
+    "mrs_peacock": (0, 3),
+    "professor_plum": (0, 1),
 }
 
 

--- a/server/ws/clueless.py
+++ b/server/ws/clueless.py
@@ -25,7 +25,7 @@ clue_cards: Dict[str, List[str]] = {
     ],
 }
 
-character_positions: Dict[str, Tuple] = {
+starting_positions: Dict[str, Tuple] = {
     "miss_scarlett": (4, 0),
     "colonel_mustard": (6, 2),
     "mrs_white": (4, 6),
@@ -52,7 +52,8 @@ hallways_positions: List[Tuple] = [
 
 class Clueless:
     """
-    A Clue-Less game instance processes moves, accusations, and suggestions.
+    A Clue-Less game instance that processes moves, accusations, and
+    suggestions.
     """
 
     def __init__(self, id: str, player_count: int) -> None:
@@ -68,7 +69,15 @@ class Clueless:
         self.id = id
         self.player_count = player_count
         self.characters = []
-        self.character_positions = character_positions
+        self.character_positions: Dict[str, Tuple] = {}
+        self.weapon_positions: Dict[str, Tuple] = {
+            "knife": (-1, -1),
+            "candle_stick": (-1, -1),
+            "revolver": (-1, -1),
+            "rope": (-1, -1),
+            "lead_pipe": (-1, -1),
+            "wrench": (-1, -1),
+        }
         self.character_cards = {}
         self.clue_cards = deepcopy(clue_cards)
         self.winner = None
@@ -83,6 +92,7 @@ class Clueless:
         """
         if not self.is_full():
             self.characters.append(character)
+            self.character_positions[character] = starting_positions[character]
             self.character_cards[character] = []
 
             if self.is_full():
@@ -142,22 +152,22 @@ class Clueless:
         """
         return self.player_count == len(self.characters)
 
-    def character_in_hallway(self, x, y) -> bool:
-        """Checks if a character is currently occupying a given hallway
+    def character_in_room(self, x, y) -> bool:
+        """Checks if a character is currently occupying a given room
 
         Parameters
         ----------
         x : int
-            The x-coordinate of the hallway
+            The x-coordinate of the room
         y : int
-            The y-coordinate of the hallway
+            The y-coordinate of the room
 
         Returns
         -------
         bool
-            True if a character is in the hallway, else False
+            True if a character is in the room, else False
         """
-        for position in character_positions.values():
+        for position in self.character_positions.values():
             if position == (x, y):
                 return True
 
@@ -169,7 +179,7 @@ class Clueless:
         Parameters
         ----------
         character : str
-            _description_
+            The character to move
         x : int
             The x-coordinate to move to
         y : int
@@ -204,15 +214,31 @@ class Clueless:
         ):
             raise RuntimeError(f"Invalid move by {character}!")
 
-        if new_position in hallways_positions and self.character_in_hallway(x, y):
+        if new_position in hallways_positions and self.character_in_room(x, y):
             raise RuntimeError(
                 f"Invalid move by {character}! Hallway is currently occupied."
             )
 
         self.character_positions[character] = new_position
 
-    def suggest(self, suspect: str, weapon: str):
-        raise RuntimeError(f"Suggestion ({suspect}, {weapon})")
+    def suggest(self, character: str, suspect: str, weapon: str) -> None:
+        """Processes a suggestion
+
+        Parameters
+        ----------
+        character : str
+            The character making the suggestion
+        suspect : str
+            The suspect being suggested
+        weapon : str
+            The weapon being suggested
+        """
+        if self.character_positions[character] in hallways_positions:
+            raise RuntimeError("Cannot make a suggestion from a hallway!")
+
+        # Move the suspect and weapon to the character's room
+        self.character_positions[suspect] = self.character_positions[character]
+        self.weapon_positions[weapon] = self.character_positions[character]
 
     def accuse(self, character: str, suspect: str, weapon: str, room: str) -> None:
         """Processes an accusation to determine if a player has won the game

--- a/server/ws/clueless.py
+++ b/server/ws/clueless.py
@@ -1,6 +1,6 @@
 import random
 
-clue_cards = {
+clue_cards: dict[str, list[str]] = {
     "suspects": [
         "miss_scarlett",
         "colonel_mustard",
@@ -23,7 +23,7 @@ clue_cards = {
     ],
 }
 
-character_positions = {
+character_positions: dict[str, tuple] = {
     "miss_scarlett": (3, 0),
     "colonel_mustard": (4, 1),
     "mrs_white": (3, 4),
@@ -35,7 +35,7 @@ character_positions = {
 
 class Clueless:
     """
-    A Clue-Less game
+    A Clue-Less game instance
     """
 
     def __init__(self):

--- a/server/ws/clueless.py
+++ b/server/ws/clueless.py
@@ -1,6 +1,8 @@
 import random
+from copy import deepcopy
+from typing import Dict, List, Tuple
 
-clue_cards: dict[str, list[str]] = {
+clue_cards: Dict[str, List[str]] = {
     "suspects": [
         "miss_scarlett",
         "colonel_mustard",
@@ -23,13 +25,13 @@ clue_cards: dict[str, list[str]] = {
     ],
 }
 
-character_positions: dict[str, tuple] = {
-    "miss_scarlett": (3, 0),
-    "colonel_mustard": (4, 1),
-    "mrs_white": (3, 4),
-    "mr_green": (1, 4),
-    "mrs_peacock": (0, 3),
-    "professor_plum": (0, 1),
+character_positions: Dict[str, Tuple] = {
+    "miss_scarlett": (4, 0),
+    "colonel_mustard": (6, 2),
+    "mrs_white": (4, 6),
+    "mr_green": (2, 6),
+    "mrs_peacock": (0, 4),
+    "professor_plum": (0, 2),
 }
 
 
@@ -38,12 +40,14 @@ class Clueless:
     A Clue-Less game instance
     """
 
-    def __init__(self):
+    def __init__(self, id, player_count):
+        self.id = id
+        self.player_count = player_count
         self.moves = []
         self.characters = []
         self.character_positions = character_positions
         self.winner = None
-        self.clue_cards = clue_cards
+        self.clue_cards = deepcopy(clue_cards)
 
         # Randomly generate the winning solution when the game is initialized
         self.solution = {
@@ -65,10 +69,29 @@ class Clueless:
         character : str
             The character to add
         """
-        self.characters.append(character)
+        if not self.is_full():
+            self.characters.append(character)
+        else:
+            raise RuntimeError("Game is currently full!")
 
     def get_characters(self):
         return self.characters
+
+    def get_available_characters(self):
+        if self.is_full():
+            return []
+        else:
+            return [
+                character
+                for character in clue_cards["suspects"]
+                if character not in self.characters
+            ]
+
+    def get_id(self):
+        return self.id
+
+    def is_full(self):
+        return self.player_count == len(self.characters)
 
     def move(self, character: str, x, y) -> None:
         x_current, y_current = self.character_positions[character]

--- a/server/ws/clueless.py
+++ b/server/ws/clueless.py
@@ -34,7 +34,7 @@ character_positions: Dict[str, Tuple] = {
     "professor_plum": (0, 2),
 }
 
-hallway_posistions: List[Tuple] = [
+hallways_positions: List[Tuple] = [
     (2, 1),
     (4, 1),
     (1, 2),
@@ -52,18 +52,26 @@ hallway_posistions: List[Tuple] = [
 
 class Clueless:
     """
-    A Clue-Less game instance
+    A Clue-Less game instance processes moves, accusations, and suggestions.
     """
 
-    def __init__(self, id, player_count):
+    def __init__(self, id: str, player_count: int) -> None:
+        """Initialize a game of Clue-Less
+
+        Parameters
+        ----------
+        id : str
+            The game ID
+        player_count : int
+            The number of players that must join before the game commences
+        """
         self.id = id
         self.player_count = player_count
-        self.moves = []
         self.characters = []
         self.character_positions = character_positions
         self.character_cards = {}
-        self.winner = None
         self.clue_cards = deepcopy(clue_cards)
+        self.winner = None
 
     def add_character(self, character: str) -> None:
         """Adds a character to the game
@@ -95,17 +103,22 @@ class Clueless:
         else:
             raise RuntimeError("Game is currently full!")
 
-    def get_available_characters(self):
-        if self.is_full():
-            return []
-        else:
-            return [
-                character
-                for character in clue_cards["suspects"]
-                if character not in self.characters
-            ]
+    def get_available_characters(self) -> None:
+        """Gets a list of unchosen characters
 
-    def distribute_cards(self):
+        Returns
+        -------
+        List[str]
+            The list of characters not yet chosen
+        """
+        return [
+            character
+            for character in clue_cards["suspects"]
+            if character not in self.characters
+        ]
+
+    def distribute_cards(self) -> None:
+        """Shuffles and evenly distributes Clue cards to all players"""
         if not self.is_full():
             raise RuntimeError("Cannot distribute cards until game is full!")
 
@@ -119,66 +132,109 @@ class Clueless:
         for index, card in enumerate(all_cards):
             self.character_cards[self.characters[index % character_count]].append(card)
 
-    def is_full(self):
+    def is_full(self) -> bool:
+        """Checks if the current game is full
+
+        Returns
+        -------
+        bool
+            True if the game is full, else False
+        """
         return self.player_count == len(self.characters)
 
-    def character_in_hallway(self, x, y):
+    def character_in_hallway(self, x, y) -> bool:
+        """Checks if a character is currently occupying a given hallway
+
+        Parameters
+        ----------
+        x : int
+            The x-coordinate of the hallway
+        y : int
+            The y-coordinate of the hallway
+
+        Returns
+        -------
+        bool
+            True if a character is in the hallway, else False
+        """
         for position in character_positions.values():
             if position == (x, y):
                 return True
 
         return False
 
-    def move(self, character: str, x, y) -> None:
+    def move(self, character: str, x: int, y: int) -> None:
+        """Moves a character to a given square
+
+        Parameters
+        ----------
+        character : str
+            _description_
+        x : int
+            The x-coordinate to move to
+        y : int
+            The y-coordinate to move to
+
+        Raises
+        ------
+        RuntimeError
+            If a move is invalid
+        """
         x_current, y_current = self.character_positions[character]
+        new_position = (x, y)
 
-        # Characters cannot move more than one square in any direction (except
-        # for secret passages)
-        if (abs(x - x_current) > 1 or abs(y - y_current) > 1) or (
-            abs(x - x_current) == 1 and abs(y - y_current) == 1
+        secret_passages = {
+            ((1, 1), (5, 5)),
+            ((5, 5), (1, 1)),
+            ((5, 1), (1, 5)),
+            ((1, 5), (5, 1)),
+        }
+
+        is_secret_passage = (
+            (x_current, y_current),
+            new_position,
+        ) in secret_passages or (
+            (new_position),
+            (x_current, y_current),
+        ) in secret_passages
+
+        if not is_secret_passage and (
+            (abs(x - x_current) > 1 or abs(y - y_current) > 1)
+            or (abs(x - x_current) == 1 and abs(y - y_current) == 1)
         ):
-            # Check for secret passages
-            if ((x_current, y_current), (x, y)) in [((0, 0), (4, 4)), ((4, 4), (0, 0))]:
-                character_positions[character] = (x, y)
-            elif ((x_current, y_current), (x, y)) in [
-                ((4, 0), (0, 4)),
-                ((0, 4), (4, 0)),
-            ]:
-                character_positions[character] = (x, y)
-            else:
-                raise RuntimeError(f"Invalid move by {character}!")
+            raise RuntimeError(f"Invalid move by {character}!")
 
-        # Each hallway only holds up to one character
-        if (x, y) in hallway_posistions and self.character_in_hallway(x, y):
+        if new_position in hallways_positions and self.character_in_hallway(x, y):
             raise RuntimeError(
                 f"Invalid move by {character}! Hallway is currently occupied."
             )
 
-        character_positions[character] = (x, y)
+        self.character_positions[character] = new_position
 
     def suggest(self, suspect: str, weapon: str):
         raise RuntimeError(f"Suggestion ({suspect}, {weapon})")
 
-    def accuse(self, suspect: str, weapon: str, room: str):
-        """Makes an accusation
+    def accuse(self, character: str, suspect: str, weapon: str, room: str) -> None:
+        """Processes an accusation to determine if a player has won the game
 
         Parameters
         ----------
+        character : str
+            The character making the accusation
         suspect : str
-            The suspect
+            The suspect being accused
         weapon : str
-            The weapon
+            The weapon being accused
         room : room
-            The room
+            The room being accused
         """
-
         if (
             suspect == self.solution["suspect"]
             and weapon == self.solution["weapon"]
             and room == self.solution["room"]
         ):
             if self.winner is None:
-                self.winner = self.characters[0]
+                self.winner = character
         else:
             raise RuntimeError(
                 "False accusation! Solution is {} with the {} in the {}".format(

--- a/server/ws/consumers.py
+++ b/server/ws/consumers.py
@@ -128,7 +128,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
             except RuntimeError as exc:
                 await self.error(str(exc))
         except KeyError:
-            await self.error(f"Game with ID {event["join"]} not found!")
+            await self.error("Game with ID {} not found!".format(event["join"]))
             return
 
         # Add the player to the channel group
@@ -150,7 +150,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         try:
             game = WATCH_GAMES[event["watch"]]
         except KeyError:
-            await self.error(f"Game with ID {event["watch"]} not found!")
+            await self.error("Game with ID {} not found!".format(event["watch"]))
             return
 
         await self.channel_layer.group_add(game.get_id(), self.channel_name)
@@ -169,7 +169,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         try:
             game = JOIN_GAMES[event["game"]]
         except KeyError:
-            await self.error(f"Game with ID {event["join"]} not found!")
+            await self.error("Game with ID {} not found!".format(event["game"]))
             return
 
         try:
@@ -196,7 +196,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         try:
             game = JOIN_GAMES[event["game"]]
         except KeyError:
-            await self.error(f"Game with ID {event["join"]} not found!")
+            await self.error("Game with ID {} not found!".format(event["game"]))
             return
 
         try:
@@ -218,7 +218,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         try:
             game = JOIN_GAMES[event["game"]]
         except KeyError:
-            await self.error(f"Game with ID {event["game"]} not found!")
+            await self.error("Game with ID {} not found!".format(event["game"]))
             return
 
         try:
@@ -298,7 +298,9 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         # Get the handler based on the event type
         handler = event_handlers.get(
             event["type"],
-            lambda e: self.error(f"Received invalid event with type {e["type"]}!"),
+            lambda e: self.error(
+                "Received invalid event with type {}!".format(e["type"])
+            ),
         )
 
         if callable(handler):

--- a/server/ws/consumers.py
+++ b/server/ws/consumers.py
@@ -218,7 +218,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         except RuntimeError as exc:
             await self.error(str(exc))
 
-    @require_keys(["game_id", "suspect", "weapon", "room"])
+    @require_keys(["game_id", "character", "suspect", "weapon", "room"])
     async def accuse(self, event: Dict[str, str]) -> None:
         """Processes an accusation event
 
@@ -236,7 +236,9 @@ class CluelessConsumer(AsyncWebsocketConsumer):
 
         try:
             # Make the accusation
-            game.accuse(event["suspect"], event["weapon"], event["room"])
+            game.accuse(
+                event["character"], event["suspect"], event["weapon"], event["room"]
+            )
 
             if game.winner is not None:
                 win_event = {"type": "win", "player": game.winner}
@@ -266,7 +268,7 @@ class CluelessConsumer(AsyncWebsocketConsumer):
         query_game_event = {
             "type": "query_game",
             "valid": valid,
-            "characters": game.get_available_characters(),
+            "characters": [] if game.is_full() else game.get_available_characters(),
             "spectator": spectator,
         }
         await self.send(json.dumps(query_game_event))

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_WS_URL=ws://127.0.0.1:8000/ws/clueless

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_WS_URL=ws://clueless.cassini.dev/ws/clueless

--- a/web/src/app/game/page.tsx
+++ b/web/src/app/game/page.tsx
@@ -102,6 +102,7 @@ export default function Game() {
     if (joinId) {
       const event = {
         type: "accusation",
+        character: character,
         suspect: suspect,
         weapon: weapon,
         room: room,

--- a/web/src/app/game/page.tsx
+++ b/web/src/app/game/page.tsx
@@ -6,7 +6,10 @@ import ClueSheet from "@/components/ClueSheet";
 import Particles from "@/components/Particles";
 import SuggestionButton from "@/components/SuggestionButton";
 import TextWithCopyButton from "@/components/TextWithCopyButton";
-import { PlayerPositions } from "@/components/utils/characters";
+import {
+  GetCharacterById,
+  CharacterPositions,
+} from "@/components/utils/characters";
 import { Alert, Box, Snackbar } from "@mui/material";
 import { useEffect, useState } from "react";
 import useWebSocket, { ReadyState } from "react-use-websocket";
@@ -15,7 +18,7 @@ interface EventObject {
   type: string;
   join?: string;
   watch?: string;
-  positions?: PlayerPositions;
+  positions?: CharacterPositions;
   player?: string;
   message?: string;
 }
@@ -31,7 +34,7 @@ export default function Game() {
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const [openErrorSnackbar, setOpenErrorSnackbar] = useState(false);
   const [characterPositions, setCharacterPositions] = useState<
-    PlayerPositions | undefined
+    CharacterPositions | undefined
   >();
 
   const WS_URL = "ws://127.0.0.1:8000/ws/clueless";
@@ -113,7 +116,15 @@ export default function Game() {
       const searchParams = new URLSearchParams(document.location.search);
 
       if (searchParams.has("join")) {
-        setCharacter(searchParams.get("character"));
+        const player = searchParams.get("character");
+
+        setCharacter(player);
+        setCharacterPositions({
+          [player as string]: {
+            x: GetCharacterById(player as string).starting_position.x,
+            y: GetCharacterById(player as string).starting_position.y,
+          },
+        });
 
         // Player joining an existing game
         event = {
@@ -131,7 +142,12 @@ export default function Game() {
         // First player starts a new game
         const player = searchParams.get("character");
         setCharacter(player);
-        setCharacterPositions({ [player as string]: { x: 0, y: 0 } });
+        setCharacterPositions({
+          [player as string]: {
+            x: GetCharacterById(player as string).starting_position.x,
+            y: GetCharacterById(player as string).starting_position.y,
+          },
+        });
         event = {
           type: "init",
           character: player,
@@ -258,7 +274,7 @@ export default function Game() {
           </div>
           <Board
             handleRoomClick={handleRoomClick}
-            positions={characterPositions}
+            characterPositions={characterPositions}
           />
           <div className="inline-flex mt-2 justify-center space-x-4">
             <SuggestionButton handleSuggestionClick={handleSuggestionClick} />

--- a/web/src/app/game/page.tsx
+++ b/web/src/app/game/page.tsx
@@ -26,7 +26,7 @@ interface EventObject {
 export default function Game() {
   const [error, setError] = useState("");
   const [winner, setWinner] = useState("");
-  const [joinId, setJoinId] = useState("");
+  const [joinId, setJoinId] = useState<string | null>("");
   const [watchId, setWatchId] = useState("");
   const [character, setCharacter] = useState<string | null | undefined>(
     undefined,
@@ -37,11 +37,11 @@ export default function Game() {
     CharacterPositions | undefined
   >();
 
-  const WS_URL = "ws://127.0.0.1:8000/ws/clueless";
+  const WS_URL = process.env.NEXT_PUBLIC_WS_URL || null;
   const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(
     WS_URL,
     {
-      share: false,
+      share: true,
       shouldReconnect: () => true,
     },
   );
@@ -118,13 +118,8 @@ export default function Game() {
       if (searchParams.has("join")) {
         const player = searchParams.get("character");
 
+        setJoinId(searchParams.get("join"));
         setCharacter(player);
-        setCharacterPositions({
-          [player as string]: {
-            x: GetCharacterById(player as string).starting_position.x,
-            y: GetCharacterById(player as string).starting_position.y,
-          },
-        });
 
         // Player joining an existing game
         event = {
@@ -141,16 +136,13 @@ export default function Game() {
       } else {
         // First player starts a new game
         const player = searchParams.get("character");
+        const playerCount = searchParams.get("player_count");
         setCharacter(player);
-        setCharacterPositions({
-          [player as string]: {
-            x: GetCharacterById(player as string).starting_position.x,
-            y: GetCharacterById(player as string).starting_position.y,
-          },
-        });
+
         event = {
           type: "init",
           character: player,
+          player_count: playerCount,
         };
       }
       console.log(

--- a/web/src/app/game/page.tsx
+++ b/web/src/app/game/page.tsx
@@ -6,8 +6,21 @@ import ClueSheet from "@/components/ClueSheet";
 import Particles from "@/components/Particles";
 import SuggestionButton from "@/components/SuggestionButton";
 import TextWithCopyButton from "@/components/TextWithCopyButton";
-import { CharacterPositions } from "@/components/utils/characters";
-import { Alert, Box, Snackbar } from "@mui/material";
+import { GetCardInfo } from "@/components/utils/cards";
+import {
+  CharacterPositions,
+  CharacterCards,
+  GetCardsByCharacter,
+} from "@/components/utils/characters";
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  CardMedia,
+  Snackbar,
+  Typography,
+} from "@mui/material";
 import { useEffect, useState } from "react";
 import useWebSocket, { ReadyState } from "react-use-websocket";
 
@@ -16,6 +29,7 @@ interface EventObject {
   join?: string;
   watch?: string;
   positions?: CharacterPositions;
+  cards?: CharacterCards;
   player?: string;
   message?: string;
 }
@@ -33,6 +47,9 @@ export default function Game() {
   const [openErrorSnackbar, setOpenErrorSnackbar] = useState(false);
   const [characterPositions, setCharacterPositions] = useState<
     CharacterPositions | undefined
+  >();
+  const [characterCards, setCharacterCards] = useState<
+    CharacterCards | undefined
   >();
 
   const WS_URL = process.env.NEXT_PUBLIC_WS_URL || null;
@@ -166,6 +183,7 @@ export default function Game() {
 
         case "start":
           setGameStarted(true);
+          if (event.cards !== undefined) setCharacterCards(event.cards);
           break;
 
         case "win":
@@ -277,6 +295,29 @@ export default function Game() {
               gameStarted={gameStarted}
             />
             <ClueSheet />
+          </div>
+          <div className="flex flex-row justify-center space-x-4 mt-4">
+            {characterCards &&
+              character &&
+              GetCardsByCharacter(character, characterCards).map((card) => (
+                <Card
+                  variant="outlined"
+                  key={card}
+                  className="ring-4"
+                  sx={{ maxWidth: 300 }}
+                >
+                  <CardMedia
+                    component="img"
+                    height={10}
+                    image={GetCardInfo(card)?.image}
+                  />
+                  <CardContent>
+                    <Typography gutterBottom variant="h5" component="div">
+                      {GetCardInfo(card)?.name}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              ))}
           </div>
 
           <Snackbar

--- a/web/src/app/game/page.tsx
+++ b/web/src/app/game/page.tsx
@@ -12,6 +12,7 @@ import {
   CharacterCards,
   GetCardsByCharacter,
 } from "@/components/utils/characters";
+import { WeaponPositions } from "@/components/utils/weapons";
 import {
   Alert,
   Box,
@@ -28,7 +29,8 @@ interface EventObject {
   type: string;
   join?: string;
   watch?: string;
-  positions?: CharacterPositions;
+  character_positions?: CharacterPositions;
+  weapon_positions?: WeaponPositions;
   cards?: CharacterCards;
   player?: string;
   message?: string;
@@ -47,6 +49,9 @@ export default function Game() {
   const [openErrorSnackbar, setOpenErrorSnackbar] = useState(false);
   const [characterPositions, setCharacterPositions] = useState<
     CharacterPositions | undefined
+  >();
+  const [weaponPositions, setWeaponPositions] = useState<
+    WeaponPositions | undefined
   >();
   const [characterCards, setCharacterCards] = useState<
     CharacterCards | undefined
@@ -76,17 +81,13 @@ export default function Game() {
     }
   }
 
-  function handleSuggestionClick(
-    suspect: string,
-    weapon: string,
-    room: string,
-  ) {
+  function handleSuggestionClick(suspect: string, weapon: string) {
     if (joinId) {
       const event = {
         type: "suggestion",
+        character: character,
         suspect: suspect,
         weapon: weapon,
-        room: room,
         game_id: joinId,
       };
 
@@ -177,8 +178,11 @@ export default function Game() {
           break;
 
         case "position":
-          if (event.positions !== undefined) {
-            setCharacterPositions(event.positions);
+          if (event.character_positions !== undefined) {
+            setCharacterPositions(event.character_positions);
+          }
+          if (event.weapon_positions !== undefined) {
+            setWeaponPositions(event.weapon_positions);
           }
           break;
 
@@ -284,6 +288,7 @@ export default function Game() {
           <Board
             handleRoomClick={handleRoomClick}
             characterPositions={characterPositions}
+            weaponPositions={weaponPositions}
             gameStarted={gameStarted}
           />
           <div className="inline-flex mt-2 justify-center space-x-4">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,27 +7,27 @@ import { Characters } from "@/components/utils/characters";
 import React from "react";
 
 export default function Home() {
-  const characterPortraits = Characters.map((character) => {
-    if (character.id === "mrs_white") {
-      return (
-        <React.Fragment key={character.id}>
-          <ImagePortrait title={character.name} image={character.image} />
-          <ImagePortrait
-            key={`${character.id}-logo`}
-            title="Clue-Less"
-            image="/logo.webp"
-          />
-        </React.Fragment>
-      );
-    } else {
-      return (
-        <ImagePortrait
-          key={character.id}
-          title={character.name}
-          image={character.image}
-        />
-      );
-    }
+  const characterPortraits = Characters.flatMap((character, index, array) => {
+    // Determine if the current character is in the middle of the array
+    const isMiddle = index === Math.floor((array.length - 1) / 2);
+
+    // Use flatMap to add the extra image when the condition is met
+    return [
+      <ImagePortrait
+        key={character.id}
+        title={character.name}
+        image={character.image}
+      />,
+      ...(isMiddle
+        ? [
+            <ImagePortrait
+              key={`${character.id}-logo`}
+              title="Clue-Less"
+              image="/logo.webp"
+            />,
+          ]
+        : []),
+    ];
   });
 
   return (

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,4 @@
-import CharacterPortrait from "@/components/CharacterPortrait";
+import ImagePortrait from "@/components/ImagePortrait";
 import StartGameButton from "@/components/StartGameButton";
 import JoinGameButton from "@/components/JoinGameButton";
 import Particles from "@/components/Particles";
@@ -11,8 +11,8 @@ export default function Home() {
     if (character.id === "mrs_white") {
       return (
         <React.Fragment key={character.id}>
-          <CharacterPortrait title={character.name} image={character.image} />
-          <CharacterPortrait
+          <ImagePortrait title={character.name} image={character.image} />
+          <ImagePortrait
             key={`${character.id}-logo`}
             title="Clue-Less"
             image="/logo.webp"
@@ -21,7 +21,7 @@ export default function Home() {
       );
     } else {
       return (
-        <CharacterPortrait
+        <ImagePortrait
           key={character.id}
           title={character.name}
           image={character.image}

--- a/web/src/components/AccusationButton.tsx
+++ b/web/src/components/AccusationButton.tsx
@@ -16,10 +16,12 @@ import { Weapons, WeaponSelections } from "./utils/weapons";
 
 interface AccusationButtonProps {
   handleAccusationClick(character: string, weapon: string, room: string): void;
+  gameStarted: Boolean;
 }
 
 export default function AccusationButton({
   handleAccusationClick,
+  gameStarted,
 }: AccusationButtonProps) {
   const [open, setOpen] = useState(false);
   const [character, setCharacter] = useState(Characters[0].id);
@@ -42,7 +44,7 @@ export default function AccusationButton({
 
   return (
     <>
-      <Button variant="outlined" onClick={handleOpen}>
+      <Button disabled={!gameStarted} variant="outlined" onClick={handleOpen}>
         <span className="pr-2">Accusation</span>{" "}
         <PsychologyAltOutlined fontSize="small" />
       </Button>

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -2,234 +2,70 @@
 
 import Square from "@/components/Square";
 import Grid from "@mui/material/Unstable_Grid2";
-import { GetCharacterByPosition, PlayerPositions } from "./utils/characters";
+import {
+  GetCharactersByPosition,
+  CharacterPositions as CharacterPositions,
+} from "./utils/characters";
+import { GetWeaponByPosition, WeaponPositions } from "./utils/weapons";
 
 interface BoardProps {
-  positions?: PlayerPositions;
+  characterPositions?: CharacterPositions;
+  weaponPositions?: WeaponPositions;
   handleRoomClick(x: Number, y: Number): void;
 }
 
-export default function Board({ positions, handleRoomClick }: BoardProps) {
+export default function Board({
+  characterPositions,
+  weaponPositions,
+  handleRoomClick,
+}: BoardProps) {
+  const rooms = [
+    { image: "/rooms/study.webp", title: "Study", x: 0, y: 0 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 0 },
+    { image: "/rooms/hall.webp", title: "Hall", x: 2, y: 0 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 0 },
+    { image: "/rooms/lounge.webp", title: "Lounge", x: 4, y: 0 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 0, y: 1 },
+    { image: "", title: "", x: 1, y: 1 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 1 },
+    { image: "", title: "", x: 3, y: 1 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 1 },
+    { image: "/rooms/library.webp", title: "Library", x: 0, y: 2 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 2 },
+    { image: "/rooms/billiard_room.webp", title: "Billiard Room", x: 2, y: 2 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 2 },
+    { image: "/rooms/dining_room.webp", title: "Dining Room", x: 4, y: 2 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 0, y: 3 },
+    { image: "", title: "", x: 1, y: 3 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 3 },
+    { image: "", title: "", x: 3, y: 3 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 3 },
+    { image: "/rooms/conservatory.webp", title: "Conservatory", x: 0, y: 4 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 4 },
+    { image: "/rooms/ballroom.webp", title: "Ballroom", x: 2, y: 4 },
+    { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 4 },
+    { image: "/rooms/kitchen.webp", title: "Kitchen", x: 4, y: 4 },
+  ];
+
   return (
     <Grid container spacing={2} columns={50}>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/study.webp"
-          title="Study"
-          x={0}
-          y={0}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(0, 0, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={1}
-          y={0}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(1, 0, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hall.webp"
-          title="Hall"
-          x={2}
-          y={0}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(2, 0, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={3}
-          y={0}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(3, 0, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/lounge.webp"
-          title="Lounge"
-          x={4}
-          y={0}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(4, 0, positions)}
-        />
-      </Grid>
-
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={0}
-          y={1}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(0, 1, positions)}
-        />
-      </Grid>
-      <Grid xs={10}></Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={2}
-          y={1}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(2, 1, positions)}
-        />
-      </Grid>
-      <Grid xs={10}></Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={4}
-          y={1}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(4, 1, positions)}
-        />
-      </Grid>
-
-      <Grid xs={10}>
-        <Square
-          image="/rooms/library.webp"
-          title="Library"
-          x={0}
-          y={2}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(0, 2, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={1}
-          y={2}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(1, 2, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/billiard_room.webp"
-          title="Billiard Room"
-          x={2}
-          y={2}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(2, 2, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={3}
-          y={2}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(3, 2, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/dining_room.webp"
-          title="Dining Room"
-          x={4}
-          y={2}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(4, 2, positions)}
-        />
-      </Grid>
-
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={0}
-          y={3}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(0, 3, positions)}
-        />
-      </Grid>
-      <Grid xs={10}></Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={2}
-          y={3}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(2, 3, positions)}
-        />
-      </Grid>
-      <Grid xs={10}></Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={4}
-          y={3}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(4, 3, positions)}
-        />
-      </Grid>
-
-      <Grid xs={10}>
-        <Square
-          image="/rooms/conservatory.webp"
-          title="Conservatory"
-          x={0}
-          y={4}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(0, 4, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={1}
-          y={4}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(1, 4, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/ballroom.webp"
-          title="Ballroom"
-          x={2}
-          y={4}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(2, 4, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/hallway.webp"
-          title="Hallway"
-          x={3}
-          y={4}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(3, 4, positions)}
-        />
-      </Grid>
-      <Grid xs={10}>
-        <Square
-          image="/rooms/kitchen.webp"
-          title="Kitchen"
-          x={4}
-          y={4}
-          handleClick={handleRoomClick}
-          character={GetCharacterByPosition(4, 4, positions)}
-        />
-      </Grid>
+      {rooms.map((room) => (
+        <Grid key={`${room.title}-${room.x}-${room.y}`} xs={10}>
+          <Square
+            image={room.image}
+            title={room.title}
+            x={room.x}
+            y={room.y}
+            handleClick={handleRoomClick}
+            characters={GetCharactersByPosition(
+              room.x,
+              room.y,
+              characterPositions,
+            )}
+            weapon={GetWeaponByPosition(room.x, room.y, weaponPositions)}
+          />
+        </Grid>
+      ))}
     </Grid>
   );
 }

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -3,10 +3,12 @@
 import Square from "@/components/Square";
 import Grid from "@mui/material/Unstable_Grid2";
 import {
+  Position,
   GetCharactersByPosition,
   CharacterPositions as CharacterPositions,
 } from "./utils/characters";
 import { GetWeaponByPosition, WeaponPositions } from "./utils/weapons";
+import { useEffect, useState } from "react";
 
 interface BoardProps {
   characterPositions?: CharacterPositions;
@@ -14,42 +16,128 @@ interface BoardProps {
   handleRoomClick(x: Number, y: Number): void;
 }
 
+const startingRooms = [
+  { image: "", title: "", x: 0, y: 0 },
+  { image: "", title: "", x: 1, y: 0 },
+  { image: "", title: "", x: 2, y: 0 },
+  { image: "", title: "", x: 3, y: 0 },
+  { image: "", title: "", x: 4, y: 0 },
+  { image: "", title: "", x: 5, y: 0 },
+  { image: "", title: "", x: 6, y: 0 },
+
+  { image: "", title: "", x: 0, y: 1 },
+  { image: "/rooms/study.webp", title: "Study", x: 1, y: 1 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 1 },
+  { image: "/rooms/hall.webp", title: "Hall", x: 3, y: 1 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 1 },
+  { image: "/rooms/lounge.webp", title: "Lounge", x: 5, y: 1 },
+  { image: "", title: "", x: 6, y: 1 },
+
+  { image: "", title: "", x: 0, y: 2 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 2 },
+  { image: "", title: "", x: 2, y: 2 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 2 },
+  { image: "", title: "", x: 4, y: 2 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 5, y: 2 },
+  { image: "", title: "", x: 6, y: 2 },
+
+  { image: "", title: "", x: 0, y: 3 },
+  { image: "/rooms/library.webp", title: "Library", x: 1, y: 3 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 3 },
+  { image: "/rooms/billiard_room.webp", title: "Billiard Room", x: 3, y: 3 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 3 },
+  { image: "/rooms/dining_room.webp", title: "Dining Room", x: 5, y: 3 },
+  { image: "", title: "", x: 6, y: 3 },
+
+  { image: "", title: "", x: 0, y: 4 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 4 },
+  { image: "", title: "", x: 2, y: 4 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 4 },
+  { image: "", title: "", x: 4, y: 4 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 5, y: 4 },
+  { image: "", title: "", x: 6, y: 4 },
+
+  { image: "", title: "", x: 0, y: 5 },
+  { image: "/rooms/conservatory.webp", title: "Conservatory", x: 1, y: 5 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 5 },
+  { image: "/rooms/ballroom.webp", title: "Ballroom", x: 3, y: 5 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 5 },
+  { image: "/rooms/kitchen.webp", title: "Kitchen", x: 5, y: 5 },
+  { image: "", title: "", x: 6, y: 5 },
+
+  { image: "", title: "", x: 0, y: 6 },
+  { image: "", title: "", x: 1, y: 6 },
+  { image: "", title: "", x: 2, y: 6 },
+  { image: "", title: "", x: 3, y: 6 },
+  { image: "", title: "", x: 4, y: 6 },
+  { image: "", title: "", x: 5, y: 6 },
+  { image: "", title: "", x: 6, y: 6 },
+];
+
+const rooms = [
+  { image: "/rooms/study.webp", title: "Study", x: 1, y: 1 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 1 },
+  { image: "/rooms/hall.webp", title: "Hall", x: 3, y: 1 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 1 },
+  { image: "/rooms/lounge.webp", title: "Lounge", x: 5, y: 1 },
+
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 2 },
+  { image: "", title: "", x: 2, y: 2 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 2 },
+  { image: "", title: "", x: 4, y: 2 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 5, y: 2 },
+
+  { image: "/rooms/library.webp", title: "Library", x: 1, y: 3 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 3 },
+  { image: "/rooms/billiard_room.webp", title: "Billiard Room", x: 3, y: 3 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 3 },
+  { image: "/rooms/dining_room.webp", title: "Dining Room", x: 5, y: 3 },
+
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 4 },
+  { image: "", title: "", x: 2, y: 4 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 4 },
+  { image: "", title: "", x: 4, y: 4 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 5, y: 4 },
+
+  { image: "/rooms/conservatory.webp", title: "Conservatory", x: 1, y: 5 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 5 },
+  { image: "/rooms/ballroom.webp", title: "Ballroom", x: 3, y: 5 },
+  { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 5 },
+  { image: "/rooms/kitchen.webp", title: "Kitchen", x: 5, y: 5 },
+];
+
 export default function Board({
   characterPositions,
   weaponPositions,
   handleRoomClick,
 }: BoardProps) {
-  const rooms = [
-    { image: "/rooms/study.webp", title: "Study", x: 0, y: 0 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 0 },
-    { image: "/rooms/hall.webp", title: "Hall", x: 2, y: 0 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 0 },
-    { image: "/rooms/lounge.webp", title: "Lounge", x: 4, y: 0 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 0, y: 1 },
-    { image: "", title: "", x: 1, y: 1 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 1 },
-    { image: "", title: "", x: 3, y: 1 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 1 },
-    { image: "/rooms/library.webp", title: "Library", x: 0, y: 2 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 2 },
-    { image: "/rooms/billiard_room.webp", title: "Billiard Room", x: 2, y: 2 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 2 },
-    { image: "/rooms/dining_room.webp", title: "Dining Room", x: 4, y: 2 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 0, y: 3 },
-    { image: "", title: "", x: 1, y: 3 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 2, y: 3 },
-    { image: "", title: "", x: 3, y: 3 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 4, y: 3 },
-    { image: "/rooms/conservatory.webp", title: "Conservatory", x: 0, y: 4 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 1, y: 4 },
-    { image: "/rooms/ballroom.webp", title: "Ballroom", x: 2, y: 4 },
-    { image: "/rooms/hallway.webp", title: "Hallway", x: 3, y: 4 },
-    { image: "/rooms/kitchen.webp", title: "Kitchen", x: 4, y: 4 },
-  ];
+  const [firstTurnComplete, setFirstTurnComplete] = useState(false);
+  const displayedRooms = firstTurnComplete ? rooms : startingRooms;
+
+  useEffect(() => {
+    let foundCharacterInStartingSquare = false;
+
+    if (characterPositions) {
+      Object.entries(characterPositions).forEach(
+        ([_, value]: [string, Position]) => {
+          if (
+            value.x === 0 ||
+            value.x === 6 ||
+            value.y === 0 ||
+            value.y === 6
+          ) {
+            foundCharacterInStartingSquare = true;
+          }
+        },
+      );
+    }
+
+    setFirstTurnComplete(!foundCharacterInStartingSquare);
+  }, [characterPositions]);
 
   return (
-    <Grid container spacing={2} columns={50}>
-      {rooms.map((room) => (
+    <Grid container spacing={1} columns={firstTurnComplete ? 50 : 70}>
+      {displayedRooms.map((room) => (
         <Grid key={`${room.title}-${room.x}-${room.y}`} xs={10}>
           <Square
             image={room.image}

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -14,6 +14,7 @@ interface BoardProps {
   characterPositions?: CharacterPositions;
   weaponPositions?: WeaponPositions;
   handleRoomClick(x: Number, y: Number): void;
+  gameStarted: Boolean;
 }
 
 const startingRooms = [
@@ -109,6 +110,7 @@ const rooms = [
 export default function Board({
   characterPositions,
   weaponPositions,
+  gameStarted,
   handleRoomClick,
 }: BoardProps) {
   const [firstTurnComplete, setFirstTurnComplete] = useState(false);
@@ -151,6 +153,7 @@ export default function Board({
               characterPositions,
             )}
             weapon={GetWeaponByPosition(room.x, room.y, weaponPositions)}
+            gameStarted={gameStarted}
           />
         </Grid>
       ))}

--- a/web/src/components/ClueSheet.tsx
+++ b/web/src/components/ClueSheet.tsx
@@ -83,38 +83,34 @@ type Room =
   | "lounge"
   | "study";
 
-// prettier-ignore
-// TODO: consolidate these definitions with a loop
 const initialSuspectCheckboxStates: SuspectCheckboxStates = {
-  "miss_scarlett": Array(7).fill(false),
-  "colonel_mustard": Array(7).fill(false),
-  "mrs_white": Array(7).fill(false),
-  "mr_green": Array(7).fill(false),
-  "mrs_peacock": Array(7).fill(false),
-  "professor_plum": Array(7).fill(false),
-}
-
-// prettier-ignore
-const initialWeaponCheckboxStates: WeaponCheckboxStates = {
-  "knife": Array(7).fill(false),
-  "candle_stick": Array(7).fill(false),
-  "revolver": Array(7).fill(false),
-  "rope": Array(7).fill(false),
-  "lead_pipe": Array(7).fill(false),
-  "wrench": Array(7).fill(false),
+  miss_scarlett: Array(7).fill(false),
+  colonel_mustard: Array(7).fill(false),
+  mrs_white: Array(7).fill(false),
+  mr_green: Array(7).fill(false),
+  mrs_peacock: Array(7).fill(false),
+  professor_plum: Array(7).fill(false),
 };
 
-// prettier-ignore
+const initialWeaponCheckboxStates: WeaponCheckboxStates = {
+  knife: Array(7).fill(false),
+  candle_stick: Array(7).fill(false),
+  revolver: Array(7).fill(false),
+  rope: Array(7).fill(false),
+  lead_pipe: Array(7).fill(false),
+  wrench: Array(7).fill(false),
+};
+
 const initialRoomCheckboxStates: RoomCheckboxStates = {
-  "ballroom": Array(7).fill(false),
-  "billiard_room": Array(7).fill(false),
-  "conservatory": Array(7).fill(false),
-  "dining_room": Array(7).fill(false),
-  "hall": Array(7).fill(false),
-  "kitchen": Array(7).fill(false),
-  "library": Array(7).fill(false),
-  "lounge": Array(7).fill(false),
-  "study": Array(7).fill(false),
+  ballroom: Array(7).fill(false),
+  billiard_room: Array(7).fill(false),
+  conservatory: Array(7).fill(false),
+  dining_room: Array(7).fill(false),
+  hall: Array(7).fill(false),
+  kitchen: Array(7).fill(false),
+  library: Array(7).fill(false),
+  lounge: Array(7).fill(false),
+  study: Array(7).fill(false),
 };
 
 function a11yProps(index: number) {

--- a/web/src/components/ImagePortrait.tsx
+++ b/web/src/components/ImagePortrait.tsx
@@ -1,18 +1,18 @@
 import { Avatar, Box, Tooltip } from "@mui/material";
 
-interface CharacterPortraitProps {
+interface ImagePortraitProps {
   title: string;
   image: string;
   width?: number;
   height?: number;
 }
 
-export default function CharacterPortrait({
+export default function ImagePortrait({
   title,
   image,
   width = 150,
   height = 150,
-}: CharacterPortraitProps) {
+}: ImagePortraitProps) {
   return (
     <Tooltip title={title}>
       <Avatar

--- a/web/src/components/JoinGameButton.tsx
+++ b/web/src/components/JoinGameButton.tsx
@@ -55,7 +55,7 @@ export default function JoinGameButton() {
     if (open && gameId.length > 0) {
       let event = {
         type: "query_game",
-        id: gameId,
+        game_id: gameId,
       };
 
       sendJsonMessage(event);

--- a/web/src/components/JoinGameButton.tsx
+++ b/web/src/components/JoinGameButton.tsx
@@ -3,37 +3,94 @@
 import PersonAddAlt1 from "@mui/icons-material/PersonAddAlt1";
 import Button from "@mui/material/Button";
 import {
+  Alert,
+  AlertTitle,
   Box,
-  Checkbox,
   Dialog,
   DialogActions,
   DialogTitle,
   FormControl,
-  FormControlLabel,
   InputLabel,
   Link,
   Select,
   SelectChangeEvent,
   TextField,
 } from "@mui/material";
-import { useState } from "react";
-import { CharacterSelections, Characters } from "./utils/characters";
+import { useEffect, useState } from "react";
+import { AvailableCharacterSelections } from "./utils/characters";
+import useWebSocket, { ReadyState } from "react-use-websocket";
 
 export default function JoinGameButton() {
+  const WS_URL = process.env.NEXT_PUBLIC_WS_URL || null;
+  const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(
+    WS_URL,
+    {
+      share: true,
+      reconnectInterval: 5,
+      shouldReconnect: () => true,
+    },
+  );
+
   const [gameId, setGameId] = useState("");
   const [open, setOpen] = useState(false);
-  const [character, setCharacter] = useState(Characters[0].id);
-  const [spectatorChecked, setSpectatorChecked] = useState(false);
+  const [valid, setValid] = useState(false);
+  const [character, setCharacter] = useState("");
+  const [spectator, setSpectator] = useState(false);
+  const [characters, setCharacters] = useState<string[]>([]);
   const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
-
-  function handleSpectatorCheck() {
-    setSpectatorChecked(!spectatorChecked);
-  }
-
+  const handleClose = () => {
+    setGameId("");
+    setCharacter("");
+    setCharacters([]);
+    setOpen(false);
+  };
   const handleCharacterChange = (event: SelectChangeEvent) => {
     setCharacter(event.target.value as string);
   };
+
+  useEffect(() => {
+    setCharacters([]);
+    setSpectator(false);
+    setValid(false);
+    if (open && gameId.length > 0) {
+      let event = {
+        type: "query_game",
+        id: gameId,
+      };
+
+      sendJsonMessage(event);
+    }
+  }, [open, gameId, sendJsonMessage]);
+
+  // Run when a new WebSocket message is received (lastJsonMessage)
+  useEffect(() => {
+    if (
+      lastJsonMessage &&
+      typeof lastJsonMessage === "object" &&
+      "type" in lastJsonMessage
+    ) {
+      console.log(
+        `Received event from backend: ${JSON.stringify(lastJsonMessage, null, 2)}`,
+      );
+
+      const event = lastJsonMessage as any;
+      switch (event.type) {
+        case "query_game":
+          setSpectator(event.spectator);
+          setValid(event.valid);
+          if (event.characters !== undefined) {
+            setCharacters(event.characters);
+            if (event.characters.length > 0) {
+              setCharacter(event.characters[0]);
+            }
+          }
+          break;
+
+        default:
+          throw new Error(`Unsupported event type: ${event.type}.`);
+      }
+    }
+  }, [lastJsonMessage]);
 
   return (
     <>
@@ -60,38 +117,63 @@ export default function JoinGameButton() {
               }}
             />
           </FormControl>
-          <FormControl fullWidth>
-            <InputLabel>Character</InputLabel>
-            <Select
-              value={character}
-              label="Character"
-              onChange={handleCharacterChange}
-              disabled={spectatorChecked}
-            >
-              {CharacterSelections}
-            </Select>
-          </FormControl>
-          <FormControlLabel
-            control={
-              <Checkbox
-                value={spectatorChecked}
-                onChange={handleSpectatorCheck}
-              />
-            }
-            label="Join as Spectator?"
-          />
+          {characters.length > 0 && !spectator && (
+            <FormControl fullWidth>
+              <InputLabel>Character</InputLabel>
+              <Select
+                value={character}
+                label="Character"
+                onChange={handleCharacterChange}
+              >
+                {AvailableCharacterSelections({ characters })}
+              </Select>
+            </FormControl>
+          )}
         </Box>
+        {readyState !== ReadyState.OPEN && (
+          <Alert severity="error" className="rounded mt-2 ml-2 mr-2">
+            <AlertTitle>Error</AlertTitle>
+            Clue-Less game server is currently offline!
+          </Alert>
+        )}
+        {readyState === ReadyState.OPEN && gameId.length > 0 && !valid && (
+          <Alert severity="error" className="rounded mt-2 ml-2 mr-2">
+            <AlertTitle>Error</AlertTitle>
+            Invalid game ID!
+          </Alert>
+        )}
+        {readyState === ReadyState.OPEN &&
+          gameId.length > 0 &&
+          valid &&
+          characters.length === 0 && (
+            <Alert severity="error" className="rounded mt-2 ml-2 mr-2">
+              <AlertTitle>Error</AlertTitle>
+              Game is currently full!
+            </Alert>
+          )}
+        {spectator && (
+          <Alert severity="info" className="rounded mt-2 ml-2 mr-2">
+            You will join the game as a spectator.
+          </Alert>
+        )}
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
-          <Link
-            href={
-              spectatorChecked
-                ? `/game?watch=${gameId}`
-                : `/game?join=${gameId}&character=${character}`
-            }
-          >
-            <Button variant="contained">Join</Button>
-          </Link>
+          {(readyState !== ReadyState.OPEN || character.length === 0) && (
+            <Button variant="contained" disabled>
+              Join
+            </Button>
+          )}
+          {readyState === ReadyState.OPEN && character.length > 0 && (
+            <Link
+              href={
+                spectator
+                  ? `/game?watch=${gameId}`
+                  : `/game?join=${gameId}&character=${character}`
+              }
+            >
+              <Button variant="contained">Join</Button>
+            </Link>
+          )}
         </DialogActions>
       </Dialog>
     </>

--- a/web/src/components/Square.tsx
+++ b/web/src/components/Square.tsx
@@ -27,8 +27,39 @@ export default function Square({
   width = 500,
   height = 500,
 }: SquareProps) {
+  function getClasses() {
+    if (y === 0) {
+      return "items-end justify-center";
+    } else if (y === 6) {
+      return "items-start justify-center";
+    } else if (x === 6) {
+      return "items-center justify-start";
+    } else if (x === 0) {
+      return "items-center justify-end";
+    }
+  }
+
+  const classes = getClasses();
+
   return (
     <>
+      {title.length === 0 && (
+        <div className={`relative min-h-[130px] flex ${classes}`}>
+          {characters &&
+            characters.map((character) => {
+              return (
+                <div key={character.id} className={`absolute`}>
+                  <ImagePortrait
+                    title={character.name}
+                    image={character.image}
+                    width={70}
+                    height={70}
+                  />
+                </div>
+              );
+            })}
+        </div>
+      )}
       {title.length > 0 && (
         <Button variant="outlined" onClick={() => handleClick(x, y)}>
           <Tooltip title={title}>
@@ -43,7 +74,6 @@ export default function Square({
 
               {characters &&
                 characters.map((character, index) => {
-                  // -left-14 top-12
                   let position = "";
                   if (index === 0) {
                     position = "left-0 top-0";

--- a/web/src/components/Square.tsx
+++ b/web/src/components/Square.tsx
@@ -1,6 +1,8 @@
 import { Button, Tooltip } from "@mui/material";
 import Image from "next/image";
 import { Character } from "./utils/characters";
+import ImagePortrait from "./ImagePortrait";
+import { Weapon } from "./utils/weapons";
 
 interface SquareProps {
   title: string;
@@ -10,7 +12,8 @@ interface SquareProps {
   handleClick(x: Number, y: Number): void;
   width?: number;
   height?: number;
-  character?: Character;
+  characters?: Character[];
+  weapon?: Weapon;
 }
 
 export default function Square({
@@ -18,34 +21,62 @@ export default function Square({
   image,
   x,
   y,
-  character,
+  characters,
+  weapon,
   handleClick,
   width = 500,
   height = 500,
 }: SquareProps) {
   return (
-    <Button variant="outlined" onClick={() => handleClick(x, y)}>
-      <Tooltip title={title}>
-        <div className="relative">
-          <Image
-            alt={title}
-            src={image}
-            width={width}
-            height={height}
-            className="z-0"
-          ></Image>
+    <>
+      {title.length > 0 && (
+        <Button variant="outlined" onClick={() => handleClick(x, y)}>
+          <Tooltip title={title}>
+            <div className="relative">
+              <Image
+                alt={title}
+                src={image}
+                width={width}
+                height={height}
+                className="z-0"
+              />
 
-          {character && (
-            <Image
-              alt={character.name}
-              src={character.image}
-              width={70}
-              height={70}
-              className="absolute inset-1"
-            ></Image>
-          )}
-        </div>
-      </Tooltip>
-    </Button>
+              {characters &&
+                characters.map((character, index) => {
+                  // -left-14 top-12
+                  let position = "";
+                  if (index === 0) {
+                    position = "left-0 top-0";
+                  } else {
+                    position = "right-0 top-0";
+                  }
+
+                  return (
+                    <div key={character.id} className={`absolute ${position}`}>
+                      <ImagePortrait
+                        title={character.name}
+                        image={character.image}
+                        width={70}
+                        height={70}
+                      />
+                    </div>
+                  );
+                })}
+
+              {weapon && (
+                <div className="absolute -bottom-4 -left-4">
+                  <ImagePortrait
+                    title={weapon.name}
+                    image={weapon.image}
+                    width={70}
+                    height={70}
+                  />
+                </div>
+              )}
+            </div>
+          </Tooltip>
+        </Button>
+      )}
+    </>
   );
 }

--- a/web/src/components/Square.tsx
+++ b/web/src/components/Square.tsx
@@ -83,8 +83,10 @@ export default function Square({
                   let position = "";
                   if (index === 0) {
                     position = "left-0 top-0";
-                  } else {
+                  } else if (index === 1) {
                     position = "right-0 top-0";
+                  } else if (index === 2) {
+                    position = "bottom-0 left-0";
                   }
 
                   return (
@@ -100,7 +102,7 @@ export default function Square({
                 })}
 
               {weapon && (
-                <div className="absolute -bottom-4 -left-4">
+                <div className="absolute bottom-0 right-0">
                   <ImagePortrait
                     title={weapon.name}
                     image={weapon.image}

--- a/web/src/components/Square.tsx
+++ b/web/src/components/Square.tsx
@@ -10,10 +10,11 @@ interface SquareProps {
   x: Number;
   y: Number;
   handleClick(x: Number, y: Number): void;
-  width?: number;
-  height?: number;
   characters?: Character[];
   weapon?: Weapon;
+  gameStarted: Boolean;
+  width?: number;
+  height?: number;
 }
 
 export default function Square({
@@ -24,6 +25,7 @@ export default function Square({
   characters,
   weapon,
   handleClick,
+  gameStarted,
   width = 500,
   height = 500,
 }: SquareProps) {
@@ -61,7 +63,11 @@ export default function Square({
         </div>
       )}
       {title.length > 0 && (
-        <Button variant="outlined" onClick={() => handleClick(x, y)}>
+        <Button
+          disabled={!gameStarted}
+          variant="outlined"
+          onClick={() => handleClick(x, y)}
+        >
           <Tooltip title={title}>
             <div className="relative">
               <Image

--- a/web/src/components/StartGameButton.tsx
+++ b/web/src/components/StartGameButton.tsx
@@ -2,6 +2,8 @@
 
 import RocketLaunchOutlined from "@mui/icons-material/RocketLaunchOutlined";
 import {
+  Alert,
+  AlertTitle,
   Box,
   Button,
   Dialog,
@@ -16,20 +18,16 @@ import {
 import { useState } from "react";
 import { CharacterSelections, Characters } from "@/components/utils/characters";
 import Link from "next/link";
-
-const style = {
-  position: "absolute" as "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  width: 800,
-  bgcolor: "black",
-  border: "2px solid #000",
-  boxShadow: 24,
-  p: 4,
-};
+import useWebSocket, { ReadyState } from "react-use-websocket";
 
 export default function StartGameButton() {
+  const WS_URL = process.env.NEXT_PUBLIC_WS_URL || null;
+  const { readyState } = useWebSocket(WS_URL, {
+    share: true,
+    reconnectInterval: 5,
+    shouldReconnect: () => true,
+  });
+
   const [open, setOpen] = useState(false);
   const [character, setCharacter] = useState(Characters[0].id);
   const [playerCount, setPlayerCount] = useState("3");
@@ -71,10 +69,10 @@ export default function StartGameButton() {
             </Select>
           </FormControl>
           <FormControl fullWidth>
-            <InputLabel>Maximum Player Count</InputLabel>
+            <InputLabel>Player Count</InputLabel>
             <Select
               value={playerCount}
-              label="Maximum Player Count"
+              label="Player Count"
               onChange={handlePlayerCountChange}
             >
               {["3", "4", "5", "6"].map((count) => (
@@ -85,13 +83,26 @@ export default function StartGameButton() {
             </Select>
           </FormControl>
         </Box>
+        {readyState !== ReadyState.OPEN && (
+          <Alert severity="error" className="rounded mt-2 ml-2 mr-2">
+            <AlertTitle>Error</AlertTitle>
+            Clue-Less game server is currently offline!
+          </Alert>
+        )}
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
-          <Link
-            href={`/game?character=${character}&player_count=${playerCount}`}
-          >
-            <Button variant="contained">Start</Button>
-          </Link>
+          {readyState !== ReadyState.OPEN && (
+            <Button variant="contained" disabled>
+              Start
+            </Button>
+          )}
+          {readyState === ReadyState.OPEN && (
+            <Link
+              href={`/game?character=${character}&player_count=${playerCount}`}
+            >
+              <Button variant="contained">Start</Button>
+            </Link>
+          )}
         </DialogActions>
       </Dialog>
     </>

--- a/web/src/components/StartGameButton.tsx
+++ b/web/src/components/StartGameButton.tsx
@@ -9,16 +9,11 @@ import {
   DialogTitle,
   FormControl,
   InputLabel,
-  ListItemText,
   MenuItem,
   Select,
   SelectChangeEvent,
-  ToggleButton,
-  ToggleButtonGroup,
-  Typography,
 } from "@mui/material";
 import { useState } from "react";
-import CharacterPortrait from "@/components/CharacterPortrait";
 import { CharacterSelections, Characters } from "@/components/utils/characters";
 import Link from "next/link";
 

--- a/web/src/components/SuggestionButton.tsx
+++ b/web/src/components/SuggestionButton.tsx
@@ -15,10 +15,12 @@ import { Weapons, WeaponSelections } from "./utils/weapons";
 
 interface SuggestionButtonProps {
   handleSuggestionClick(character: string, weapon: string, room: string): void;
+  gameStarted: Boolean;
 }
 
 export default function SuggestionButton({
   handleSuggestionClick,
+  gameStarted,
 }: SuggestionButtonProps) {
   const [open, setOpen] = useState(false);
   const [character, setCharacter] = useState(Characters[0].id);
@@ -36,7 +38,7 @@ export default function SuggestionButton({
 
   return (
     <>
-      <Button variant="contained" onClick={handleOpen}>
+      <Button disabled={!gameStarted} variant="contained" onClick={handleOpen}>
         <span className="pr-2">Suggestion</span>{" "}
         <QuestionMarkOutlined fontSize="small" />
       </Button>

--- a/web/src/components/SuggestionButton.tsx
+++ b/web/src/components/SuggestionButton.tsx
@@ -14,7 +14,7 @@ import { Characters, CharacterSelections } from "./utils/characters";
 import { Weapons, WeaponSelections } from "./utils/weapons";
 
 interface SuggestionButtonProps {
-  handleSuggestionClick(character: string, weapon: string, room: string): void;
+  handleSuggestionClick(character: string, weapon: string): void;
   gameStarted: Boolean;
 }
 
@@ -73,8 +73,7 @@ export default function SuggestionButton({
           <Button
             variant="contained"
             onClick={() => {
-              // TODO: Update room with current players room
-              handleSuggestionClick(character, weapon, "study");
+              handleSuggestionClick(character, weapon);
               handleClose();
             }}
           >

--- a/web/src/components/utils/cards.tsx
+++ b/web/src/components/utils/cards.tsx
@@ -1,0 +1,25 @@
+import { Characters } from "./characters";
+import { Rooms } from "./rooms";
+import { Weapons } from "./weapons";
+
+export function GetCardInfo(card: string) {
+  for (const character of Characters) {
+    if (card === character.id) {
+      return character;
+    }
+  }
+
+  for (const weapon of Weapons) {
+    if (card === weapon.id) {
+      return weapon;
+    }
+  }
+
+  for (const room of Rooms) {
+    if (card === room.id) {
+      return room;
+    }
+  }
+
+  return undefined;
+}

--- a/web/src/components/utils/characters.tsx
+++ b/web/src/components/utils/characters.tsx
@@ -1,11 +1,13 @@
 import { Box, ListItemText, MenuItem } from "@mui/material";
-import CharacterPortrait from "../CharacterPortrait";
+import ImagePortrait from "../ImagePortrait";
 export interface Character {
+  id: string;
   name: string;
   image: string;
+  starting_position: Position;
 }
 
-export interface PlayerPositions {
+export interface CharacterPositions {
   [player: string]: {
     x: number;
     y: number;
@@ -22,31 +24,55 @@ export const Characters = [
     id: "miss_scarlett",
     name: "Miss Scarlett",
     image: "/characters/miss_scarlett.webp",
+    starting_position: {
+      x: 3,
+      y: 0,
+    },
   },
   {
     id: "colonel_mustard",
     name: "Colonel Mustard",
     image: "/characters/colonel_mustard.webp",
+    starting_position: {
+      x: 4,
+      y: 1,
+    },
   },
   {
     id: "mrs_white",
     name: "Mrs. White",
     image: "/characters/mrs_white.webp",
+    starting_position: {
+      x: 3,
+      y: 4,
+    },
   },
   {
     id: "mr_green",
     name: "Mr. Green",
     image: "/characters/mr_green.webp",
+    starting_position: {
+      x: 1,
+      y: 4,
+    },
   },
   {
     id: "mrs_peacock",
     name: "Mrs. Peacock",
     image: "/characters/mrs_peacock.webp",
+    starting_position: {
+      x: 0,
+      y: 3,
+    },
   },
   {
     id: "professor_plum",
     name: "Professor Plum",
     image: "/characters/professor_plum.webp",
+    starting_position: {
+      x: 0,
+      y: 1,
+    },
   },
 ];
 
@@ -61,7 +87,7 @@ export const CharacterSelections = Characters.map((character) => (
       }}
     >
       <ListItemText primary={character.name} />
-      <CharacterPortrait
+      <ImagePortrait
         image={character.image}
         title={character.name}
         width={50}
@@ -78,23 +104,26 @@ export function GetCharacterById(id: string) {
     }
   }
 
-  return undefined;
+  return Characters[0];
 }
 
-export function GetCharacterByPosition(
+export function GetCharactersByPosition(
   x: Number,
   y: Number,
-  positions?: PlayerPositions,
+  positions?: CharacterPositions,
 ) {
-  let character = undefined;
+  let characters: Character[] = [];
 
   if (positions) {
     Object.entries(positions).forEach(([player, value]: [string, Position]) => {
       if (x === value.x && y === value.y) {
-        character = GetCharacterById(player);
+        const character = GetCharacterById(player);
+        if (character) {
+          characters.push(character);
+        }
       }
     });
   }
 
-  return character;
+  return characters;
 }

--- a/web/src/components/utils/characters.tsx
+++ b/web/src/components/utils/characters.tsx
@@ -4,7 +4,6 @@ export interface Character {
   id: string;
   name: string;
   image: string;
-  starting_position: Position;
 }
 
 export interface CharacterPositions {
@@ -14,7 +13,7 @@ export interface CharacterPositions {
   };
 }
 
-interface Position {
+export interface Position {
   x: number;
   y: number;
 }
@@ -24,55 +23,31 @@ export const Characters = [
     id: "miss_scarlett",
     name: "Miss Scarlett",
     image: "/characters/miss_scarlett.webp",
-    starting_position: {
-      x: 3,
-      y: 0,
-    },
   },
   {
     id: "colonel_mustard",
     name: "Colonel Mustard",
     image: "/characters/colonel_mustard.webp",
-    starting_position: {
-      x: 4,
-      y: 1,
-    },
   },
   {
     id: "mrs_white",
     name: "Mrs. White",
     image: "/characters/mrs_white.webp",
-    starting_position: {
-      x: 3,
-      y: 4,
-    },
   },
   {
     id: "mr_green",
     name: "Mr. Green",
     image: "/characters/mr_green.webp",
-    starting_position: {
-      x: 1,
-      y: 4,
-    },
   },
   {
     id: "mrs_peacock",
     name: "Mrs. Peacock",
     image: "/characters/mrs_peacock.webp",
-    starting_position: {
-      x: 0,
-      y: 3,
-    },
   },
   {
     id: "professor_plum",
     name: "Professor Plum",
     image: "/characters/professor_plum.webp",
-    starting_position: {
-      x: 0,
-      y: 1,
-    },
   },
 ];
 
@@ -97,6 +72,36 @@ export const CharacterSelections = Characters.map((character) => (
   </MenuItem>
 ));
 
+export const AvailableCharacterSelections = ({
+  characters,
+}: {
+  characters: string[];
+}) => {
+  return Characters.map(
+    (character) =>
+      characters.includes(character.id) && (
+        <MenuItem value={character.id} key={character.id}>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              width: "100%",
+            }}
+          >
+            <ListItemText primary={character.name} />
+            <ImagePortrait
+              image={character.image}
+              title={character.name}
+              width={50}
+              height={50}
+            />
+          </Box>
+        </MenuItem>
+      ),
+  );
+};
+
 export function GetCharacterById(id: string) {
   for (const character of Characters) {
     if (character.id === id) {
@@ -104,7 +109,7 @@ export function GetCharacterById(id: string) {
     }
   }
 
-  return Characters[0];
+  return undefined;
 }
 
 export function GetCharactersByPosition(

--- a/web/src/components/utils/characters.tsx
+++ b/web/src/components/utils/characters.tsx
@@ -13,6 +13,10 @@ export interface CharacterPositions {
   };
 }
 
+export interface CharacterCards {
+  [player: string]: string[];
+}
+
 export interface Position {
   x: number;
   y: number;
@@ -110,6 +114,23 @@ export function GetCharacterById(id: string) {
   }
 
   return undefined;
+}
+
+export function GetCardsByCharacter(
+  character?: string,
+  characterCards?: CharacterCards,
+) {
+  let cards: string[] = [];
+
+  if (characterCards && character) {
+    Object.entries(characterCards).map(([player, playerCards]) => {
+      if (player === character) {
+        cards = playerCards;
+      }
+    });
+  }
+
+  return cards;
 }
 
 export function GetCharactersByPosition(

--- a/web/src/components/utils/weapons.tsx
+++ b/web/src/components/utils/weapons.tsx
@@ -5,6 +5,18 @@ export interface Weapon {
   image: string;
 }
 
+export interface WeaponPositions {
+  [weapon: string]: {
+    x: number;
+    y: number;
+  };
+}
+
+interface Position {
+  x: number;
+  y: number;
+}
+
 export const Weapons = [
   {
     id: "knife",
@@ -57,3 +69,31 @@ export const WeaponSelections = Weapons.map((weapon) => (
     </Box>
   </MenuItem>
 ));
+
+export function GetWeaponById(id: string) {
+  for (const weapon of Weapons) {
+    if (weapon.id === id) {
+      return weapon;
+    }
+  }
+
+  return Weapons[0];
+}
+
+export function GetWeaponByPosition(
+  x: Number,
+  y: Number,
+  positions?: WeaponPositions,
+) {
+  let weapon = undefined;
+
+  if (positions) {
+    Object.entries(positions).forEach(([player, value]: [string, Position]) => {
+      if (x === value.x && y === value.y) {
+        weapon = GetWeaponById(player);
+      }
+    });
+  }
+
+  return weapon;
+}


### PR DESCRIPTION
- Adds support for multiple players joining from a different browser window or browser tab
  - This utilizes the Django [channel layers](https://channels.readthedocs.io/en/latest/topics/channel_layers.html) functionality which enables multiple connections to be added to a channel layer group. Messages can then be broadcast to the entire group. For example, when two players connect to the WebSocket, they will be added to the same group. Move events are then broadcasted to the entire group so each player's browser window updates with the latest position of each player in the game.
  - Note that the channel layers functionality requires [Redis](https://redis.io/) to be running in the background or the WebSocket server will fail to initialize. Redis can be easily run using Docker with the following command: `docker run -p 6379:6379 -d redis:5`. 
  - The WebSocket consumer was also updated to be asynchronous which improves performance
- Adds two environment files (`.env.development` and `.env.production`) that define the WebSocket endpoint depending on what environment the frontend is running in. This uses the [environment variables](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables) support built-in to Next.js. When running locally, the `.env.development` URL will be used which connects to `localhost` backend. When running on the actual web domain, the `.env.production` URL will be used which connects to the production backend.
- The board now places each character in the correct starting square. To support this, the board begins as a 7x7 grid in which each character is placed adjacent to their starting hallway. Once all characters have moved from their starting squares into the adjacent hallway, the board collapses back to a 5x5 grid to consume less space.
- Adds support for placing weapon icons on board squares
- Characters are now displayed on the board as circular Avatar's instead of squares
- The start game modal and join game modal now check the current WebSocket status before allowing a player to start a game. If the WebSocket connection could not be established, an error message is displayed in the modal and the button is disabled. The WebSocket connection is automatically shared between each component.
- The join game modal now validates game ID's input by the user. To support this functionality, a new `query_game` message is sent from the frontend to the backend. The backend responds with a message if the game is found. The message includes what characters are available in the game and if the ID is for spectating. The frontend uses this information to display what characters are available for selection and to inform the user if they will be joining as a spectator. The user will also be informed if the current game is full.
- It is now possible to join the game as a spectator. Upon joining, the WebSocket consumer will add the connection to the channel layer group and the spectating player will receive broadcast events whenever a real player performs an action.
- When all players have moved from their starting squares, the backend sends a new `start` event that includes the Clue cards dealt to each player. The backend shuffles all available cards and distributes them evenly among players.
- Improves event validation and error handling in the WebSocket consumer